### PR TITLE
Fix segfault / SYSABRT error on invalid certificate files

### DIFF
--- a/src/TLSServer.h
+++ b/src/TLSServer.h
@@ -65,6 +65,7 @@ private:
   int                              _queue;
   bool                             _debug;
   enum trust_level                 _trust;
+  bool                             _priorities_init;
 };
 
 class TLSTransaction


### PR DESCRIPTION
Previously, if certificate files were readable, but invalid, a
segfault could arise from ~TLSServer, since an exception is thrown
before _credentials and _priorities were properly set up, thus the
gnutls de-init functions get an invalid pointer.

In addition, gnutls_priority_init can fail in such a way that the
_priorities pointer is valid, but trying to de-initialize it will
raise SIGABRT. Thus, the boolean variable _priorities_init was
added so that if an exception is thrown before this operation
completes, the exception will propagate correctly and the
destructor will not raise SIGABRT.

The call to gnutls_global_deinit() is no longer required on gnutls
>= 3.3.0 (according to gnutls documentation)


(note I discovered this whilst trying to set up a taskd server on opensuse Leap 42.3)