### PR TITLE
RFC/RFT: implement taskserver behind SSL proxy

### DIFF
--- a/doc/man/taskdrc.5.in
+++ b/doc/man/taskdrc.5.in
@@ -81,6 +81,16 @@ The address (IPv4, IPv6 or DNS) of the Taskserver, followed by a colon and the
 port number.
 
 .TP
+.B server.proxy=on
+Offloads SSL connection handling to a reverse proxy.  Connections are accepted
+unencrypted and wrapped with PROXYv2 protocol.
+
+This is appropriate for service behind haproxy configured with
+"send-proxy-v2" server option. Optional SSL information is ignored.
+
+Defaults to off.
+
+.TP
 .B server.cert=/path/to/server.cert.pem
 Fully qualified path to the server certificate.
 

--- a/doc/man/taskdrc.5.in
+++ b/doc/man/taskdrc.5.in
@@ -86,7 +86,8 @@ Offloads SSL connection handling to a reverse proxy.  Connections are accepted
 unencrypted and wrapped with PROXYv2 protocol.
 
 This is appropriate for service behind haproxy configured with
-"send-proxy-v2" server option. Optional SSL information is ignored.
+"send-proxy-v2" server option or behind stunnel with "protocol = proxy".
+Optional SSL information is ignored.
 
 Defaults to off.
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -14,6 +14,7 @@ add_library (taskd admin.cpp
                    Database.cpp   Database.h
                    help.cpp
                    init.cpp
+                   ProxyServer.cpp  ProxyServer.h
                    Server.cpp     Server.h
                    Task.cpp       Task.h
                    TCPServer.cpp  TCPServer.h

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -16,6 +16,7 @@ add_library (taskd admin.cpp
                    init.cpp
                    Server.cpp     Server.h
                    Task.cpp       Task.h
+                   TCPServer.cpp  TCPServer.h
                    TLSClient.cpp  TLSClient.h
                    TLSServer.cpp  TLSServer.h
                    util.cpp       util.h)

--- a/src/ProxyServer.cpp
+++ b/src/ProxyServer.cpp
@@ -1,0 +1,116 @@
+////////////////////////////////////////////////////////////////////////////////
+//
+// Copyright 2019, Göteborg Bit Factory.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+// THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+// http://www.opensource.org/licenses/mit-license.php
+//
+////////////////////////////////////////////////////////////////////////////////
+
+#include <stdint.h>
+#include <string.h>
+#include <format.h>
+#include <netinet/in.h>
+#include <ProxyServer.h>
+
+// PROXY protocol as specified in https://www.haproxy.org/download/1.8/doc/proxy-protocol.txt
+
+static const char PROXYv2_SIG[12] = { '\r', '\n', '\r', '\n', 0, '\r', '\n', 'Q', 'U', 'I', 'T', '\n' };
+static const size_t PROXYv2_HEADER_LEN = 16;
+static const size_t PROXYv2_ADDRv4_LEN = 12;
+static const size_t PROXYv2_ADDRv6_LEN = 36;
+
+////////////////////////////////////////////////////////////////////////////////
+void ProxyTransaction::accept (int socket, struct sockaddr *sa_remote)
+{
+  _socket = socket;
+
+  char buf[0x10000];
+
+  if (! process_proxy_v2(sa_remote, buf))
+    throw "bad PROXYv2 signature received";
+
+  TCPTransaction::accept (socket, sa_remote);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+static void fill_proxy_ipv4(struct sockaddr_in& sa, char *& buf, size_t& hlen)
+{
+  if (hlen < PROXYv2_ADDRv4_LEN)
+    throw format ("too short PROXY address for IPv4 ({1} bytes)", hlen);
+  sa.sin_family = AF_INET;
+  memcpy (&sa.sin_port, buf + 8, 2);
+  memcpy (&sa.sin_addr, buf + 0, 4);
+  buf += PROXYv2_ADDRv4_LEN;
+  hlen -= PROXYv2_ADDRv4_LEN;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+static void fill_proxy_ipv6(struct sockaddr_in6& sa, char *& buf, size_t& hlen)
+{
+  if (hlen < PROXYv2_ADDRv6_LEN)
+    throw format ("too short PROXY address for IPv6 ({1} bytes)", hlen);
+  memset (&sa, 0, sizeof(sa));
+  sa.sin6_family = AF_INET6;
+  memcpy (&sa.sin6_port, buf + 32, 2);
+  memcpy (&sa.sin6_addr, buf + 0, 16);
+  buf += PROXYv2_ADDRv6_LEN;
+  hlen -= PROXYv2_ADDRv6_LEN;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+bool ProxyTransaction::process_proxy_v2 (struct sockaddr *sa_remote, char *buf)
+{
+  if (do_recv (buf, PROXYv2_HEADER_LEN) < PROXYv2_HEADER_LEN)
+    throw "EOF before PROXYv2 signature";
+  if (memcmp (buf, PROXYv2_SIG, sizeof(PROXYv2_SIG)))
+    return false;
+
+  char proxycmd = buf[12];
+  char afproto = buf[13];
+  if (proxycmd != 0x20 && proxycmd != 0x21)
+    throw format ("unsupported PROXYv2 protocol+command byte {1}", formatHex (proxycmd));
+
+  size_t hlen = ((unsigned char)buf[14] << 8) | (unsigned char)buf[15];
+
+  if (hlen > 0)
+  {
+    if (do_recv (buf, hlen) < hlen)
+      throw "EOF in PROXYv2 header";
+  }
+
+  switch (afproto) {
+  case 0x00:
+    sa_remote->sa_family = AF_UNSPEC;
+    break;
+  case 0x11: /* IPv4/TCP */
+    fill_proxy_ipv4 (*(struct sockaddr_in *)sa_remote, buf, hlen);
+    break;
+  case 0x21: /* IPv6/TCP */
+    fill_proxy_ipv6 (*(struct sockaddr_in6 *)sa_remote, buf, hlen);
+    break;
+  default:
+    throw format ("unsupported PROXYv2 original protocol byte {1}", formatHex (afproto));
+  }
+
+  return true;
+}
+
+////////////////////////////////////////////////////////////////////////////////

--- a/src/ProxyServer.cpp
+++ b/src/ProxyServer.cpp
@@ -28,10 +28,13 @@
 #include <string.h>
 #include <format.h>
 #include <netinet/in.h>
+#include <arpa/inet.h>
 #include <ProxyServer.h>
 
 // PROXY protocol as specified in https://www.haproxy.org/download/1.8/doc/proxy-protocol.txt
 
+static const char PROXYv1_SIG[6] = { 'P', 'R', 'O', 'X', 'Y', ' ' };
+static const size_t PROXYv1_MAX_REQ_LEN = 108 - sizeof(PROXYv1_SIG);
 static const char PROXYv2_SIG[12] = { '\r', '\n', '\r', '\n', 0, '\r', '\n', 'Q', 'U', 'I', 'T', '\n' };
 static const size_t PROXYv2_HEADER_LEN = 16;
 static const size_t PROXYv2_ADDRv4_LEN = 12;
@@ -44,10 +47,106 @@ void ProxyTransaction::accept (int socket, struct sockaddr *sa_remote)
 
   char buf[0x10000];
 
-  if (! process_proxy_v2(sa_remote, buf))
-    throw "bad PROXYv2 signature received";
+  if (! process_proxy_v1(sa_remote, buf))
+    if (! process_proxy_v2(sa_remote, buf))
+      throw "bad PROXY signature received";
 
   TCPTransaction::accept (socket, sa_remote);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+static void parse_proxy_address (char *buf, int af, void *addr, in_port_t& port)
+{
+  // buf: "SRCIP DSTIP SPORT DPORT"
+
+  char *e = strchr (buf, ' ');
+  if (e == NULL)
+    throw "bad PROXY request format";
+  *e++ = 0;
+
+  if (inet_pton (af, buf, addr) != 1)
+    throw "bad PROXY request format";
+
+  buf = strchr (e, ' ');
+  if (buf++ == NULL)
+    throw "bad PROXY request format";
+
+  e = strchr (buf, ' ');
+  if (e == NULL)
+    throw "bad PROXY request format";
+  *e = 0;
+
+  errno = 0;
+  port = strtoul (buf, &e, 10);
+  if (!*buf || *e || errno)
+    throw "bad PROXY request format";
+}
+
+////////////////////////////////////////////////////////////////////////////////
+static void parse_proxy_ipv4 (struct sockaddr_in& sa, char *buf)
+{
+  sa.sin_family = AF_INET;
+  parse_proxy_address (buf, AF_INET, &sa.sin_addr, sa.sin_port);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+static void parse_proxy_ipv6 (struct sockaddr_in6& sa, char *buf)
+{
+  memset (&sa, 0, sizeof(sa));
+  sa.sin6_family = AF_INET6;
+  parse_proxy_address (buf, AF_INET6, &sa.sin6_addr, sa.sin6_port);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+bool ProxyTransaction::recv_line (char *buf, size_t max_len)
+{
+  size_t offs = 0;
+  do
+  {
+    do
+    {
+      if (do_recv (buf + offs, 2) < 2)
+        return false;
+      offs += 2;
+    }
+    while (offs < max_len && buf[offs - 1] != '\n' && buf[offs - 1] != '\r');
+
+    if (buf[offs - 1] == '\r')
+    {
+      if (do_recv (buf + offs++, 1) == 0)
+        return false;
+    }
+  }
+  while (offs < max_len && buf[offs - 1] != '\n');
+
+  if (buf[--offs] != '\n')
+    throw "PROXY request too big";
+  buf[--offs] = 0;
+
+  return true;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+bool ProxyTransaction::process_proxy_v1 (struct sockaddr *sa_remote, char *buf)
+{
+  if (do_recv (buf, sizeof(PROXYv1_SIG)) < sizeof(PROXYv1_SIG))
+    throw "EOF before PROXY signature";
+  if (memcmp (buf, PROXYv1_SIG, sizeof(PROXYv1_SIG)))
+    return false;
+
+  if (!recv_line (buf, PROXYv1_MAX_REQ_LEN))
+    throw "EOF in PROXY request";
+
+  if (!strncmp (buf, "UNKNOWN", 7))
+    sa_remote->sa_family = AF_UNSPEC;
+  else if (!strncmp (buf, "TCP4 ", 5))
+    parse_proxy_ipv4 (*(struct sockaddr_in *)sa_remote, buf + 5);
+  else if (!strncmp (buf, "TCP6 ", 5))
+    parse_proxy_ipv6 (*(struct sockaddr_in6 *)sa_remote, buf + 5);
+  else
+    throw "invalid PROXY request protocol";
+
+  return true;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -78,8 +177,9 @@ static void fill_proxy_ipv6(struct sockaddr_in6& sa, char *& buf, size_t& hlen)
 ////////////////////////////////////////////////////////////////////////////////
 bool ProxyTransaction::process_proxy_v2 (struct sockaddr *sa_remote, char *buf)
 {
-  if (do_recv (buf, PROXYv2_HEADER_LEN) < PROXYv2_HEADER_LEN)
-    throw "EOF before PROXYv2 signature";
+  static const size_t PROXYv2_HEADER_REMAINDER = PROXYv2_HEADER_LEN - sizeof(PROXYv1_SIG);
+  if (do_recv (buf + sizeof(PROXYv1_SIG), PROXYv2_HEADER_REMAINDER) < PROXYv2_HEADER_REMAINDER)
+    throw "EOF in PROXYv2 signature";
   if (memcmp (buf, PROXYv2_SIG, sizeof(PROXYv2_SIG)))
     return false;
 

--- a/src/ProxyServer.h
+++ b/src/ProxyServer.h
@@ -36,6 +36,8 @@ public:
   void accept (int , struct sockaddr *) override;
 
 private:
+  bool recv_line(char *, size_t);
+  bool process_proxy_v1 (struct sockaddr *, char *);
   bool process_proxy_v2 (struct sockaddr *, char *);
 };
 

--- a/src/ProxyServer.h
+++ b/src/ProxyServer.h
@@ -1,0 +1,44 @@
+////////////////////////////////////////////////////////////////////////////////
+//
+// Copyright 2019, Göteborg Bit Factory.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+// THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+// http://www.opensource.org/licenses/mit-license.php
+//
+////////////////////////////////////////////////////////////////////////////////
+#ifndef INCLUDED_PROXYSERVER
+#define INCLUDED_PROXYSERVER
+
+#include <string>
+#include "TCPServer.h"
+
+class ProxyTransaction : public TCPTransaction
+{
+public:
+  explicit ProxyTransaction(TCPServer&) {}
+  void accept (int , struct sockaddr *) override;
+
+private:
+  bool process_proxy_v2 (struct sockaddr *, char *);
+};
+
+#endif
+
+////////////////////////////////////////////////////////////////////////////////

--- a/src/Server.cpp
+++ b/src/Server.cpp
@@ -191,7 +191,7 @@ void Server::setConfig (Config* c)
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-void Server::beginServer ()
+void Server::configureTLSServer ()
 {
   if (_config)
   {
@@ -200,6 +200,12 @@ void Server::beginServer ()
     setKeyFile (_config->get ("server.key"));
     setCRLFile (_config->get ("server.crl"));
   }
+}
+
+////////////////////////////////////////////////////////////////////////////////
+void Server::beginServer ()
+{
+  configureTLSServer ();
 
   if (_log) _log->write ("Server starting");
 
@@ -217,6 +223,36 @@ void Server::beginServer ()
     throw std::string ("Failed to register handler for SIGUSR2... Exiting.");
 
   TLSServer server;
+  initTLSServer (server);
+  server.queue (_queue_size);
+  server.bind (_host, _port, _family);
+  server.listen ();
+
+  if (_log) _log->write ("Server ready");
+
+  _request_count = 0;
+  while (1)
+  {
+    try
+    {
+      if (_sighup)
+        throw "SIGHUP shutdown.";
+
+      Timer timer;
+      processTLSTransaction (server, timer);
+
+      if (_log) _log->write (format ("[{1}] Serviced in {2}s", _request_count, (timer.total_us () / 1e6)));
+    }
+
+    catch (std::string& e) { if (_log) _log->write (std::string ("Error: ") + e); }
+    catch (char* e)        { if (_log) _log->write (std::string ("Error: ") + e); }
+    catch (...)            { if (_log) _log->write ("Error: Unknown exception"); }
+  }
+}
+
+////////////////////////////////////////////////////////////////////////////////
+void Server::initTLSServer (TLSServer& server)
+{
   if (_config)
   {
     server.debug (_config->getInteger ("debug.tls"));
@@ -251,55 +287,35 @@ void Server::beginServer ()
                _crl_file,       // CRL
                _cert_file,      // Cert
                _key_file);      // Key
-  server.queue (_queue_size);
-  server.bind (_host, _port, _family);
-  server.listen ();
+}
 
-  if (_log) _log->write ("Server ready");
+////////////////////////////////////////////////////////////////////////////////
+void Server::processTLSTransaction (TLSServer& server, Timer& timer)
+{
+  TLSTransaction tx;
+  tx.trust (server.trust ());
+  server.accept (tx);
 
-  _request_count = 0;
-  while (1)
-  {
-    try
-    {
-      TLSTransaction tx;
-      tx.trust (server.trust ());
-      server.accept (tx);
+  // Get client address and port, for logging.
+  if (_log_clients)
+    tx.getClient (_client_address, _client_port);
 
-      if (_sighup)
-        throw "SIGHUP shutdown.";
+  // Metrics.
+  timer.start ();
 
-      // Get client address and port, for logging.
-      if (_log_clients)
-        tx.getClient (_client_address, _client_port);
+  std::string input;
+  tx.recv (input);
 
-      // Metrics.
-      Timer timer;
-      timer.start ();
+  // Handle the request.
+  ++_request_count;
 
-      std::string input;
-      tx.recv (input);
+  // Call the derived class handler.
+  std::string output;
+  handler (input, output);
+  if (output.length ())
+    tx.send (output);
 
-      // Handle the request.
-      ++_request_count;
-
-      // Call the derived class handler.
-      std::string output;
-      handler (input, output);
-      if (output.length ())
-        tx.send (output);
-
-      if (_log)
-      {
-        timer.stop ();
-        _log->write (format ("[{1}] Serviced in {2}s", _request_count, (timer.total_us () / 1e6)));
-      }
-    }
-
-    catch (std::string& e) { if (_log) _log->write (std::string ("Error: ") + e); }
-    catch (char* e)        { if (_log) _log->write (std::string ("Error: ") + e); }
-    catch (...)            { if (_log) _log->write ("Error: Unknown exception"); }
-  }
+  timer.stop ();
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/src/Server.cpp
+++ b/src/Server.cpp
@@ -130,9 +130,11 @@ void Server::setLimit (int max)
 ////////////////////////////////////////////////////////////////////////////////
 void Server::setCAFile (const std::string& file)
 {
+  File cert (file);
+  if (! cert.exists ())
+    return;
   if (_log) _log->write (format ("CA          {1}", file));
   _ca_file = file;
-  File cert (file);
   if (! cert.readable ())
     throw format ("CA Certificate not readable: '{1}'", file);
 }
@@ -160,9 +162,11 @@ void Server::setKeyFile (const std::string& file)
 ////////////////////////////////////////////////////////////////////////////////
 void Server::setCRLFile (const std::string& file)
 {
+  File crl (file);
+  if (! crl.exists ())
+    return;
   if (_log) _log->write (format ("CRL         {1}", file));
   _crl_file = file;
-  File crl (file);
   if (! crl.readable ())
     throw format ("CRL Certificate not readable: '{1}'", file);
 }
@@ -189,6 +193,14 @@ void Server::setConfig (Config* c)
 ////////////////////////////////////////////////////////////////////////////////
 void Server::beginServer ()
 {
+  if (_config)
+  {
+    setCAFile (_config->get ("ca.cert"));
+    setCertFile (_config->get ("server.cert"));
+    setKeyFile (_config->get ("server.key"));
+    setCRLFile (_config->get ("server.crl"));
+  }
+
   if (_log) _log->write ("Server starting");
 
   if (_daemon)

--- a/src/Server.cpp
+++ b/src/Server.cpp
@@ -239,7 +239,7 @@ void Server::beginServer ()
         throw "SIGHUP shutdown.";
 
       Timer timer;
-      processTLSTransaction (server, timer);
+      processTransaction (server, timer);
 
       if (_log) _log->write (format ("[{1}] Serviced in {2}s", _request_count, (timer.total_us () / 1e6)));
     }
@@ -290,10 +290,9 @@ void Server::initTLSServer (TLSServer& server)
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-void Server::processTLSTransaction (TLSServer& server, Timer& timer)
+void Server::processTransaction (TLSServer& server, Timer& timer)
 {
-  TLSTransaction tx;
-  tx.trust (server.trust ());
+  TLSTransaction tx (server);
   server.accept (tx);
 
   // Get client address and port, for logging.

--- a/src/Server.cpp
+++ b/src/Server.cpp
@@ -253,7 +253,7 @@ void Server::beginServer ()
     }
 
     catch (std::string& e) { if (_log) _log->write (std::string ("Error: ") + e); }
-    catch (char* e)        { if (_log) _log->write (std::string ("Error: ") + e); }
+    catch (const char* e)  { if (_log) _log->write (std::string ("Error: ") + e); }
     catch (...)            { if (_log) _log->write ("Error: Unknown exception"); }
   }
 }

--- a/src/Server.h
+++ b/src/Server.h
@@ -31,6 +31,9 @@
 #include <ConfigFile.h>
 #include <Log.h>
 
+class Timer;
+class TLSServer;
+
 class Server
 {
 public:
@@ -71,6 +74,9 @@ private:
   void setCertFile (const std::string&);
   void setKeyFile (const std::string&);
   void setCRLFile (const std::string&);
+  void configureTLSServer ();
+  void initTLSServer (TLSServer& server);
+  void processTLSTransaction (TLSServer& server, Timer& timer);
 
   std::string _host            {"::"};
   std::string _port            {"53589"};

--- a/src/Server.h
+++ b/src/Server.h
@@ -76,7 +76,7 @@ private:
   void setCRLFile (const std::string&);
   void configureTLSServer ();
   void initTLSServer (TLSServer& server);
-  void processTLSTransaction (TLSServer& server, Timer& timer);
+  void processTransaction (TLSServer& server, Timer& timer);
 
   std::string _host            {"::"};
   std::string _port            {"53589"};

--- a/src/Server.h
+++ b/src/Server.h
@@ -48,10 +48,6 @@ public:
   void setLog (Log*);
   void setConfig (Config*);
   void setLimit (int);
-  void setCAFile (const std::string&);
-  void setCertFile (const std::string&);
-  void setKeyFile (const std::string&);
-  void setCRLFile (const std::string&);
   void setLogClients (bool);
   void start ();
 
@@ -71,6 +67,11 @@ protected:
   int _client_port             {0};
 
 private:
+  void setCAFile (const std::string&);
+  void setCertFile (const std::string&);
+  void setKeyFile (const std::string&);
+  void setCRLFile (const std::string&);
+
   std::string _host            {"::"};
   std::string _port            {"53589"};
   std::string _family          {"IPv6"};

--- a/src/Server.h
+++ b/src/Server.h
@@ -76,7 +76,8 @@ private:
   void setCRLFile (const std::string&);
   void configureTLSServer ();
   void initTLSServer (TLSServer& server);
-  void processTransaction (TLSServer& server, Timer& timer);
+  template <typename TTx, typename TServer>
+  void processTransaction (TServer& server, Timer& timer);
 
   std::string _host            {"::"};
   std::string _port            {"53589"};

--- a/src/TCPServer.cpp
+++ b/src/TCPServer.cpp
@@ -213,9 +213,25 @@ void TCPTransaction::accept (int socket, struct sockaddr *sa_remote)
   _socket = socket;
 
   // Obtain client info.
+  const void *in_addr;
+  unsigned short in_port;
+  switch (sa_remote->sa_family) {
+  case AF_INET:
+    in_addr = &((sockaddr_in *)sa_remote)->sin_addr;
+    in_port = ((sockaddr_in *)sa_remote)->sin_port;
+    break;
+  case AF_INET6:
+    in_addr = &((sockaddr_in6 *)sa_remote)->sin6_addr;
+    in_port = ((sockaddr_in6 *)sa_remote)->sin6_port;
+    break;
+  default:
+    throw "BUG: got unknown remote address family from accept()";
+  }
+
   char topbuf[512];
-  _address = inet_ntop (AF_INET, &sa_cli.sin_addr, topbuf, sizeof (topbuf));
-  _port    = ntohs (sa_cli.sin_port);
+  _address = inet_ntop (sa_remote->sa_family, in_addr, topbuf, sizeof (topbuf));
+  _port = ntohs (in_port);
+
   if (_debug)
     std::cout << "s: INFO connection from "
               << _address

--- a/src/TCPServer.cpp
+++ b/src/TCPServer.cpp
@@ -1,0 +1,370 @@
+////////////////////////////////////////////////////////////////////////////////
+//
+// Copyright 2006 - 2018, Göteborg Bit Factory.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+// THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+// http://www.opensource.org/licenses/mit-license.php
+//
+////////////////////////////////////////////////////////////////////////////////
+
+#include <cmake.h>
+
+#include <iostream>
+#include <unistd.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdint.h>
+#include <string.h>
+#include <TCPServer.h>
+#include <sys/socket.h>
+#include <netinet/in.h>
+#include <arpa/inet.h>
+#if (defined OPENBSD || defined SOLARIS)
+#include <errno.h>
+#else
+#include <sys/errno.h>
+#endif
+#include <sys/types.h>
+#include <netdb.h>
+#include <gnutls/x509.h>
+#include <format.h>
+
+#define DH_BITS 2048
+#define HEADER_SIZE 4
+#define MAX_BUF 16384
+
+////////////////////////////////////////////////////////////////////////////////
+TCPServer::TCPServer ()
+{
+}
+
+////////////////////////////////////////////////////////////////////////////////
+TCPServer::~TCPServer ()
+{
+  if (_socket)
+  {
+    shutdown (_socket, SHUT_RDWR);
+    close (_socket);
+  }
+}
+
+////////////////////////////////////////////////////////////////////////////////
+void TCPServer::queue (int depth)
+{
+  _queue = depth;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// Calling this method results in all subsequent socket traffic being sent to
+// std::cout, labelled with 's: ...'.
+void TCPServer::debug (int level)
+{
+  if (level)
+    _debug = true;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+void TCPServer::bind (
+  const std::string& host,
+  const std::string& port,
+  const std::string& family)
+{
+  // use IPv4 or IPv6, does not matter.
+  struct addrinfo hints {};
+  hints.ai_family   = (family == "IPv6" ? AF_INET6 :
+                       family == "IPv4" ? AF_INET  :
+                                          AF_UNSPEC);
+  hints.ai_socktype = SOCK_STREAM;
+  hints.ai_flags    = AI_PASSIVE; // use my IP
+
+  struct addrinfo* res;
+  int ret = ::getaddrinfo (host.c_str (), port.c_str (), &hints, &res);
+  if (ret != 0)
+    throw std::string (::gai_strerror (ret));
+
+  for (struct addrinfo* p = res; p != NULL; p = p->ai_next)
+  {
+    // IPv4
+    void *addr;
+    int ipver;
+    if (p->ai_family == AF_INET)
+    {
+      struct sockaddr_in *ipv4 = (struct sockaddr_in *)p->ai_addr;
+      addr = &(ipv4->sin_addr);
+      ipver = 4;
+    }
+    // IPv6
+    else
+    {
+      struct sockaddr_in6 *ipv6 = (struct sockaddr_in6 *)p->ai_addr;
+      addr = &(ipv6->sin6_addr);
+      ipver = 6;
+    }
+
+    // Convert the IP to a string and print it:
+    char ipstr[INET6_ADDRSTRLEN];
+    inet_ntop (p->ai_family, addr, ipstr, sizeof ipstr);
+    if (_debug)
+      std::cout << "s: INFO IPv" << ipver << ": " << ipstr << '\n';
+  }
+
+  if ((_socket = ::socket (res->ai_family,
+                           res->ai_socktype,
+                           res->ai_protocol)) == -1)
+    throw std::string ("Can not bind to  ") + host + port;
+
+  // When a socket is closed, it remains unavailable for a while (netstat -an).
+  // Setting SO_REUSEADDR allows this program to assume control of a closed, but
+  // unavailable socket.
+  int on = 1;
+  if (::setsockopt (_socket,
+                    SOL_SOCKET,
+                    SO_REUSEADDR,
+                    (const void*) &on,
+                    sizeof (on)) == -1)
+    throw std::string (::strerror (errno));
+
+  // Also listen to IPv4 with IPv6 in dual-stack situations
+  if (res->ai_family == AF_INET6)
+  {
+    int off = 0;
+    if (::setsockopt (_socket,
+                      IPPROTO_IPV6,
+                      IPV6_V6ONLY,
+                      (const void*) &off,
+                      sizeof (off)) == -1)
+      if (_debug)
+        std::cout << "s: Unable to use IPv6 dual stack\n";
+  }
+
+  if (::bind (_socket, res->ai_addr, res->ai_addrlen) == -1)
+  {
+    // TODO This is research to determine whether this is the right location to
+    //      inject a helpful log message, such as
+    //
+    //      "Check to see if the server is already running."
+    std::cout << "### bind failed\n";
+    throw std::string (::strerror (errno));
+  }
+}
+
+////////////////////////////////////////////////////////////////////////////////
+void TCPServer::listen ()
+{
+  if (::listen (_socket, _queue) < 0)
+    throw std::string (::strerror (errno));
+
+  if (_debug)
+    std::cout << "s: INFO Server listening.\n";
+}
+
+////////////////////////////////////////////////////////////////////////////////
+void TCPServer::accept (TCPTransaction& tx)
+{
+  if (_debug)
+    tx.debug ();
+
+  struct sockaddr_in sa_cli {};
+  socklen_t client_len = sizeof sa_cli;
+  int conn;
+  do
+  {
+    conn = ::accept (_socket, (struct sockaddr *) &sa_cli, &client_len);
+  }
+  while (errno == EINTR);
+
+  if (conn < 0)
+    throw std::string (::strerror (errno));
+
+  tx.accept (conn, (struct sockaddr *)&sa_cli);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+TCPTransaction::~TCPTransaction ()
+{
+  if (_socket)
+  {
+    shutdown (_socket, SHUT_RDWR);
+    close (_socket);
+    _socket = 0;
+  }
+}
+
+////////////////////////////////////////////////////////////////////////////////
+void TCPTransaction::accept (int socket, struct sockaddr *sa_remote)
+{
+  _socket = socket;
+
+  // Obtain client info.
+  char topbuf[512];
+  _address = inet_ntop (AF_INET, &sa_cli.sin_addr, topbuf, sizeof (topbuf));
+  _port    = ntohs (sa_cli.sin_port);
+  if (_debug)
+    std::cout << "s: INFO connection from "
+              << _address
+              << " port "
+              << _port
+              << '\n';
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// Calling this method results in all subsequent socket traffic being sent to
+// std::cout, labelled with 's: ...'.
+void TCPTransaction::debug ()
+{
+  _debug = true;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+void TCPTransaction::limit (int max)
+{
+  _limit = max;
+}
+
+///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+void TCPTransaction::send (const std::string& data)
+{
+  std::string packet = "XXXX" + data;
+
+  // Encode the length.
+  unsigned long l = packet.length ();
+  packet[0] = l >>24;
+  packet[1] = l >>16;
+  packet[2] = l >>8;
+  packet[3] = l;
+
+  size_t total = 0;
+
+  try
+  {
+    total = do_send (packet.c_str (), packet.length ());
+  }
+  catch (...) {}
+
+  if (_debug)
+    std::cout << "s: INFO Sending 'XXXX"
+              << data.c_str ()
+              << "' (" << total << " bytes)"
+              << std::endl;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+size_t TCPTransaction::do_send(const void *data, size_t len)
+{
+  const char *buf = static_cast<const char *>(data);
+  size_t total = 0;
+
+  int status;
+  do
+  {
+    errno = 0;
+    status = ::send (_socket, buf + total, len - total, MSG_NOSIGNAL);
+  }
+  while ((status > 0 && (total += status) < len) ||
+          errno == EINTR || errno == EAGAIN);
+
+  if (status < 0)
+  {
+    throw std::string (strerror (errno));
+  }
+
+  return total;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+void TCPTransaction::recv (std::string& data)
+{
+  data = "";          // No appending of data.
+  size_t total = 0;
+
+  // Get the encoded length.
+  unsigned char header[HEADER_SIZE] {};
+  try
+  {
+    total = do_recv (header, HEADER_SIZE);
+  }
+  catch (std::string e) { throw std::string ("Failed to receive header: ") + e; }
+
+  if (total < HEADER_SIZE) {
+    throw std::string ("Failed to receive header: connection lost?");
+  }
+
+  // Decode the length.
+  unsigned long expected = (header[0]<<24) |
+                           (header[1]<<16) |
+                           (header[2]<<8) |
+                            header[3];
+  if (_debug)
+    std::cout << "s: INFO expecting " << expected << " bytes.\n";
+
+  if (_limit && expected >= (unsigned long) _limit) {
+    std::ostringstream err_str;
+    err_str << "Expected message size " << expected << " is larger than allowed limit " << _limit;
+    throw err_str.str ();
+  }
+
+  data.resize (expected - total);
+  total = do_recv (&data[0], data.length ());
+
+  // Other end closed the connection.
+  if (total < data.length ())
+  {
+    if (_debug)
+      std::cout << "s: INFO Peer has closed the TCP connection\n";
+  }
+
+  if (_debug)
+    std::cout << "s: INFO Receiving 'XXXX"
+              << data.c_str ()
+              << "' (" << total << " bytes)"
+              << std::endl;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+size_t TCPTransaction::do_recv (void *buffer, size_t len)
+{
+  char *buf = static_cast<char *>(buffer);
+  size_t total = 0;
+
+  int received;
+  do
+  {
+    errno = 0;
+    received = ::recv (_socket, buf + total, len - total, MSG_WAITALL);
+  }
+  while ((received > 0 && (total += received) < HEADER_SIZE) ||
+          errno == EINTR || errno == EAGAIN);
+
+  if (received < 0)
+  {
+    throw std::string (strerror (errno));
+  }
+
+  return total;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+void TCPTransaction::getClient (std::string& address, int& port)
+{
+  address = _address;
+  port = _port;
+}
+
+////////////////////////////////////////////////////////////////////////////////

--- a/src/TCPServer.h
+++ b/src/TCPServer.h
@@ -1,0 +1,77 @@
+////////////////////////////////////////////////////////////////////////////////
+//
+// Copyright 2006 - 2018, Paul Beckingham, Federico Hernandez.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+// THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+// http://www.opensource.org/licenses/mit-license.php
+//
+////////////////////////////////////////////////////////////////////////////////
+#ifndef INCLUDED_TCPSERVER
+#define INCLUDED_TCPSERVER
+
+#include <string>
+
+class TCPTransaction;
+
+class TCPServer
+{
+public:
+  TCPServer ();
+  ~TCPServer ();
+  void queue (int);
+  virtual void debug (int);
+  void bind (const std::string&, const std::string&, const std::string&);
+  void listen ();
+  void accept (TCPTransaction&);
+
+protected:
+  bool                             _debug       {false};
+
+private:
+  int                              _socket      {0};
+  int                              _queue       {5};
+};
+
+class TCPTransaction
+{
+public:
+  TCPTransaction () = default;
+  ~TCPTransaction ();
+  virtual void accept (int, struct sockaddr *);
+  void debug ();
+  void limit (int);
+  void send (const std::string&);
+  void recv (std::string&);
+  void getClient (std::string&, int&);
+
+protected:
+  virtual size_t do_send (const void *, size_t);
+  virtual size_t do_recv (void *, size_t);
+
+  int                         _socket  {0};
+  int                         _limit   {0};
+  bool                        _debug   {false};
+  std::string                 _address {""};
+  int                         _port    {0};
+};
+
+#endif
+
+////////////////////////////////////////////////////////////////////////////////

--- a/src/TLSServer.cpp
+++ b/src/TLSServer.cpp
@@ -50,8 +50,6 @@
 #include <format.h>
 
 #define DH_BITS 2048
-#define HEADER_SIZE 4
-#define MAX_BUF 16384
 
 #if GNUTLS_VERSION_NUMBER < 0x030406
 #if GNUTLS_VERSION_NUMBER >= 0x020a00
@@ -96,18 +94,6 @@ TLSServer::~TLSServer ()
   // Not needed after v3.3.0, handled automatically by library.
   gnutls_global_deinit ();
 #endif
-
-  if (_socket)
-  {
-    shutdown (_socket, SHUT_RDWR);
-    close (_socket);
-  }
-}
-
-////////////////////////////////////////////////////////////////////////////////
-void TLSServer::queue (int depth)
-{
-  _queue = depth;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -115,8 +101,7 @@ void TLSServer::queue (int depth)
 // std::cout, labelled with 's: ...'.
 void TLSServer::debug (int level)
 {
-  if (level)
-    _debug = true;
+  TCPServer::debug (level);
 
   gnutls_global_set_log_function (gnutls_log_function); // All
   gnutls_global_set_log_level (level); // All
@@ -245,124 +230,13 @@ void TLSServer::init (
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-void TLSServer::bind (
-  const std::string& host,
-  const std::string& port,
-  const std::string& family)
-{
-  // use IPv4 or IPv6, does not matter.
-  struct addrinfo hints {};
-  hints.ai_family   = (family == "IPv6" ? AF_INET6 :
-                       family == "IPv4" ? AF_INET  :
-                                          AF_UNSPEC);
-  hints.ai_socktype = SOCK_STREAM;
-  hints.ai_flags    = AI_PASSIVE; // use my IP
-
-  struct addrinfo* res;
-  int ret = ::getaddrinfo (host.c_str (), port.c_str (), &hints, &res);
-  if (ret != 0)
-    throw std::string (::gai_strerror (ret));
-
-  for (struct addrinfo* p = res; p != NULL; p = p->ai_next)
-  {
-    // IPv4
-    void *addr;
-    int ipver;
-    if (p->ai_family == AF_INET)
-    {
-      struct sockaddr_in *ipv4 = (struct sockaddr_in *)p->ai_addr;
-      addr = &(ipv4->sin_addr);
-      ipver = 4;
-    }
-    // IPv6
-    else
-    {
-      struct sockaddr_in6 *ipv6 = (struct sockaddr_in6 *)p->ai_addr;
-      addr = &(ipv6->sin6_addr);
-      ipver = 6;
-    }
-
-    // Convert the IP to a string and print it:
-    char ipstr[INET6_ADDRSTRLEN];
-    inet_ntop (p->ai_family, addr, ipstr, sizeof ipstr);
-    if (_debug)
-      std::cout << "s: INFO IPv" << ipver << ": " << ipstr << '\n';
-  }
-
-  if ((_socket = ::socket (res->ai_family,
-                           res->ai_socktype,
-                           res->ai_protocol)) == -1)
-    throw std::string ("Can not bind to  ") + host + port;
-
-  // When a socket is closed, it remains unavailable for a while (netstat -an).
-  // Setting SO_REUSEADDR allows this program to assume control of a closed, but
-  // unavailable socket.
-  int on = 1;
-  if (::setsockopt (_socket,
-                    SOL_SOCKET,
-                    SO_REUSEADDR,
-                    (const void*) &on,
-                    sizeof (on)) == -1)
-    throw std::string (::strerror (errno));
-
-  // Also listen to IPv4 with IPv6 in dual-stack situations
-  if (res->ai_family == AF_INET6)
-  {
-    int off = 0;
-    if (::setsockopt (_socket,
-                      IPPROTO_IPV6,
-                      IPV6_V6ONLY,
-                      (const void*) &off,
-                      sizeof (off)) == -1)
-      if (_debug)
-        std::cout << "s: Unable to use IPv6 dual stack\n";
-  }
-
-  if (::bind (_socket, res->ai_addr, res->ai_addrlen) == -1)
-  {
-    // TODO This is research to determine whether this is the right location to
-    //      inject a helpful log message, such as
-    //
-    //      "Check to see if the server is already running."
-    std::cout << "### bind failed\n";
-    throw std::string (::strerror (errno));
-  }
-}
-
-////////////////////////////////////////////////////////////////////////////////
-void TLSServer::listen ()
-{
-  if (::listen (_socket, _queue) < 0)
-    throw std::string (::strerror (errno));
-
-  if (_debug)
-    std::cout << "s: INFO Server listening.\n";
-}
-
-////////////////////////////////////////////////////////////////////////////////
-void TLSServer::accept (TLSTransaction& tx)
-{
-  if (_debug)
-    tx.debug ();
-
-  tx.init (*this);
-}
-
-////////////////////////////////////////////////////////////////////////////////
 TLSTransaction::~TLSTransaction ()
 {
-  if (_socket)
-  {
-    shutdown (_socket, SHUT_RDWR);
-    close (_socket);
-    _socket = 0;
-  }
-
   gnutls_deinit (_session); // All
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-void TLSTransaction::init (TLSServer& server)
+TLSTransaction::TLSTransaction (TLSServer& server)
 {
   int ret = gnutls_init (&_session, GNUTLS_SERVER); // All
   if (ret < 0)
@@ -390,27 +264,12 @@ void TLSTransaction::init (TLSServer& server)
   gnutls_session_enable_compatibility_mode (_session);
 */
 
-  struct sockaddr_in sa_cli {};
-  socklen_t client_len = sizeof sa_cli;
-  do
-  {
-    _socket = accept (server._socket, (struct sockaddr *) &sa_cli, &client_len);
-  }
-  while (errno == EINTR);
+  trust (server.trust ());
+}
 
-  if (_socket < 0)
-    throw std::string (::strerror (errno));
-
-  // Obtain client info.
-  char topbuf[512];
-  _address = inet_ntop (AF_INET, &sa_cli.sin_addr, topbuf, sizeof (topbuf));
-  _port    = ntohs (sa_cli.sin_port);
-  if (_debug)
-    std::cout << "s: INFO connection from "
-              << _address
-              << " port "
-              << _port
-              << '\n';
+void TLSTransaction::accept (int socket, struct sockaddr *sa_remote)
+{
+  TCPTransaction::accept (socket, sa_remote);
 
 #if GNUTLS_VERSION_NUMBER >= 0x030109
   gnutls_transport_set_int (_session, _socket); // 3.1.9
@@ -419,6 +278,7 @@ void TLSTransaction::init (TLSServer& server)
 #endif
 
   // Perform the TLS handshake
+  int ret;
   do
   {
     ret = gnutls_handshake (_session); // All
@@ -477,23 +337,9 @@ void TLSTransaction::bye ()
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-// Calling this method results in all subsequent socket traffic being sent to
-// std::cout, labelled with 's: ...'.
-void TLSTransaction::debug ()
-{
-  _debug = true;
-}
-
-////////////////////////////////////////////////////////////////////////////////
 void TLSTransaction::trust (const enum TLSServer::trust_level value)
 {
   _trust = value;
-}
-
-////////////////////////////////////////////////////////////////////////////////
-void TLSTransaction::limit (int max)
-{
-  _limit = max;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -598,124 +444,49 @@ int TLSTransaction::verify_certificate () const
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-void TLSTransaction::send (const std::string& data)
+size_t TLSTransaction::do_send(const void *data, size_t len)
 {
-  std::string packet = "XXXX" + data;
-
-  // Encode the length.
-  unsigned long l = packet.length ();
-  packet[0] = l >>24;
-  packet[1] = l >>16;
-  packet[2] = l >>8;
-  packet[3] = l;
-
-  unsigned int total = 0;
+  const char *buf = static_cast<const char *>(data);
+  size_t total = 0;
 
   int status;
   do
   {
-    status = gnutls_record_send (_session, packet.c_str () + total, packet.length () - total); // All
+    status = gnutls_record_send (_session, buf + total, len - total); // All
   }
-  while ((status > 0 && (total += status) < packet.length ()) ||
+  while ((status > 0 && (total += status) < len) ||
           status == GNUTLS_E_INTERRUPTED ||
           status == GNUTLS_E_AGAIN);
 
-  if (_debug)
-    std::cout << "s: INFO Sending 'XXXX"
-              << data.c_str ()
-              << "' (" << total << " bytes)"
-              << std::endl;
+  if (status < 0)
+  {
+    throw std::string (gnutls_strerror (errno));
+  }
+
+  return total;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-void TLSTransaction::recv (std::string& data)
+size_t TLSTransaction::do_recv (void *buffer, size_t len)
 {
-  data = "";          // No appending of data.
-  int received = 0;
-  int total = 0;
+  char *buf = static_cast<char *>(buffer);
+  size_t total = 0;
 
-  // Get the encoded length.
-  unsigned char header[HEADER_SIZE] {};
+  int received;
   do
   {
-    received = gnutls_record_recv (_session, header + total, HEADER_SIZE - total); // All
+      received = gnutls_record_recv (_session, buf + total, len - total);
   }
-  while ((received > 0 && (total += received) < HEADER_SIZE) ||
+  while ((received > 0 && (total += received) < len) ||
           received == GNUTLS_E_INTERRUPTED ||
           received == GNUTLS_E_AGAIN);
 
-  if (total < HEADER_SIZE) {
-    throw std::string ("Failed to receive header: ") +
-        (received < 0 ? gnutls_strerror(received) : "connection lost?");
-  }
-
-  // Decode the length.
-  unsigned long expected = (header[0]<<24) |
-                           (header[1]<<16) |
-                           (header[2]<<8) |
-                            header[3];
-  if (_debug)
-    std::cout << "s: INFO expecting " << expected << " bytes.\n";
-
-  if (_limit && expected >= (unsigned long) _limit) {
-    std::ostringstream err_str;
-    err_str << "Expected message size " << expected << " is larger than allowed limit " << _limit;
-    throw err_str.str ();
-  }
-
-  // Arbitrary buffer size.
-  char buffer[MAX_BUF];
-
-  // Keep reading until no more data.  Concatenate chunks of data if a) the
-  // read was interrupted by a signal, and b) if there is more data than
-  // fits in the buffer.
-  do
+  if (received < 0)
   {
-    int chunk_size = 0;
-    do
-    {
-      received = gnutls_record_recv (_session, buffer + chunk_size, MAX_BUF - chunk_size); // All
-      if (received > 0) {
-        total += received;
-        chunk_size += received;
-      }
-    }
-    while ((received > 0 && (unsigned long) total < expected && chunk_size < MAX_BUF) ||
-            received == GNUTLS_E_INTERRUPTED ||
-            received == GNUTLS_E_AGAIN);
-
-    // Other end closed the connection.
-    if (received == 0)
-    {
-      if (_debug)
-        std::cout << "s: INFO Peer has closed the TLS connection\n";
-      break;
-    }
-
-    // Something happened.
-    if (received < 0)
-      throw std::string (gnutls_strerror (received)); // All
-
-    data.append (buffer, chunk_size);
-
-    // Stop at defined limit.
-    if (_limit && total > _limit)
-      break;
+    throw std::string (gnutls_strerror (errno));
   }
-  while (received > 0 && total < (int) expected);
 
-  if (_debug)
-    std::cout << "s: INFO Receiving 'XXXX"
-              << data.c_str ()
-              << "' (" << total << " bytes)"
-              << std::endl;
-}
-
-////////////////////////////////////////////////////////////////////////////////
-void TLSTransaction::getClient (std::string& address, int& port)
-{
-  address = _address;
-  port = _port;
+  return total;
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/src/daemon.cpp
+++ b/src/daemon.cpp
@@ -905,20 +905,6 @@ void command_server (Database& db)
     }
 
     // It just runs until you kill it.
-    File ca (db._config->get ("ca.cert"));
-    if (ca.exists ())
-      server.setCAFile (ca._data);
-
-    File cert (db._config->get ("server.cert"));
-    server.setCertFile (cert._data);
-
-    File key (db._config->get ("server.key"));
-    server.setKeyFile (key._data);
-
-    File crl (db._config->get ("server.crl"));
-    if (crl.exists ())
-      server.setCRLFile (crl._data);
-
     server.beginServer ();
   }
 

--- a/src/diag.cpp
+++ b/src/diag.cpp
@@ -180,12 +180,12 @@ void command_diag (Database& config)
       File config_file (root_dir._data + "/config");
       std::cout << "      config: "
                 << config_file._data
-                << (config_file.readable () ? ", readable" : ", missing")
-                << (config_file.writable () ? ", writable" : ", not writable")
-                << config_file.size ()
+                << (config_file.exists () && config_file.readable () ? ", readable" : ", missing")
+                << (config_file.exists () && config_file.writable () ? ", writable" : ", not writable")
+                << (config_file.exists () ? config_file.size () : 0)
                 << " bytes\n";
 
-      if (config_file.readable ())
+      if (config_file.exists () && config_file.readable ())
       {
         // Load the config file.
         config._config->load (config_file._data);
@@ -196,20 +196,20 @@ void command_diag (Database& config)
         File server_crl  (config._config->get ("server.crl"));
 
         std::cout << "          CA: "
-                  << ca_cert._data << (ca_cert.readable () ? ", readable, " : ", ")
-                  << ca_cert.size ()
+                  << ca_cert._data << (ca_cert.exists () && ca_cert.readable () ? ", readable, " : ", ")
+                  << (ca_cert.exists () ? ca_cert.size () : 0)
                   << " bytes\n";
         std::cout << " Certificate: "
-                  << server_cert._data << (server_cert.readable () ? ", readable, " : ", missing, ")
-                  << server_cert.size ()
+                  << server_cert._data << (server_cert.exists () && server_cert.readable () ? ", readable, " : ", missing, ")
+                  << (server_cert.exists () ? server_cert.size () : 0)
                   << " bytes\n";
         std::cout << "         Key: "
-                  << server_key._data << (server_key.readable () ? ", readable, " : ", missing, ")
-                  << server_key.size ()
+                  << server_key._data << (server_key.exists () && server_key.readable () ? ", readable, " : ", missing, ")
+                  << (server_key.exists () ? server_key.size () : 0)
                   << " bytes\n";
         std::cout << "         CRL: "
-                  << server_crl._data << (server_crl.readable () ? ", readable, " : "")
-                  << server_crl.size ()
+                  << server_crl._data << (server_crl.exists () && server_crl.readable () ? ", readable, " : "")
+                  << (server_crl.exists () ? server_crl.size () : 0)
                   << " bytes\n";
 
         File log (config._config->get ("log"));

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,10 +1,4 @@
-cmake_minimum_required (VERSION 2.8)
-
-# See this CMake issue before complaining about the following.
-# https://cmake.org/Bug/view.php?id=16062
-if(POLICY CMP0037)
-  cmake_policy(SET CMP0037 OLD)
-endif()
+cmake_minimum_required (VERSION 3.11)
 
 include_directories (${CMAKE_SOURCE_DIR}
                      ${CMAKE_SOURCE_DIR}/src


### PR DESCRIPTION
This patchset allows to put taskserver behind an SSL reverse proxy (eg. stunnel or haproxy). Original client's address is passed using PROXY protocol described at [1]. Both versions of the protocol are supported, though binary (v2) is preferred.

[1] http://www.haproxy.org/download/1.8/doc/proxy-protocol.txt