### PR TITLE
systemd: make unit depend on network-online.target

### DIFF
--- a/scripts/systemd/taskd.service
+++ b/scripts/systemd/taskd.service
@@ -1,6 +1,7 @@
 [Unit]
 Description=Secure server providing multi-user, multi-client access to task data
-After=network.target
+Wants=network-online.target
+After=network-online.target
 Documentation=http://taskwarrior.org/docs/
 
 [Service]


### PR DESCRIPTION
network.target provides rather relaxed guarantees about what's available
so instead it's better to depend on network-online.target for:
- ip address to bind to might not be set up at network.target
- dns resolution might not work for hostname resolution used for server