### PR TITLE
TLS: fix multiple issues with error handling

### DIFF
--- a/src/TLSClient.cpp
+++ b/src/TLSClient.cpp
@@ -30,6 +30,7 @@
 
 #include <TLSClient.h>
 #include <iostream>
+#include <sstream>
 #include <unistd.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -48,6 +49,7 @@
 #include <shared.h>
 #include <format.h>
 
+#define HEADER_SIZE 4
 #define MAX_BUF 16384
 
 #if GNUTLS_VERSION_NUMBER < 0x030406
@@ -473,24 +475,15 @@ void TLSClient::send (const std::string& data)
   packet[3] = l;
 
   unsigned int total = 0;
-  unsigned int remaining = packet.length ();
 
-  while (total < packet.length ())
+  int status;
+  do
   {
-    int status;
-    do
-    {
-      status = gnutls_record_send (_session, packet.c_str () + total, remaining); // All
-    }
-    while (errno == GNUTLS_E_INTERRUPTED ||
-           errno == GNUTLS_E_AGAIN);
-
-    if (status == -1)
-      break;
-
-    total     += (unsigned int) status;
-    remaining -= (unsigned int) status;
+    status = gnutls_record_send (_session, packet.c_str () + total, packet.length () - total); // All
   }
+  while ((status > 0 && (total += status) < packet.length ()) ||
+          status == GNUTLS_E_INTERRUPTED ||
+          status == GNUTLS_E_AGAIN);
 
   if (_debug)
     std::cout << "c: INFO Sending 'XXXX"
@@ -504,18 +497,22 @@ void TLSClient::recv (std::string& data)
 {
   data = "";          // No appending of data.
   int received = 0;
+  int total = 0;
 
   // Get the encoded length.
-  unsigned char header[4] {};
+  unsigned char header[HEADER_SIZE] {};
   do
   {
-    received = gnutls_record_recv (_session, header, 4); // All
+    received = gnutls_record_recv (_session, header + total, HEADER_SIZE - total); // All
   }
-  while (received > 0 &&
-         (errno == GNUTLS_E_INTERRUPTED ||
-          errno == GNUTLS_E_AGAIN));
+  while ((received > 0 && (total += received) < HEADER_SIZE) ||
+          received == GNUTLS_E_INTERRUPTED ||
+          received == GNUTLS_E_AGAIN);
 
-  int total = received;
+  if (total < HEADER_SIZE) {
+    throw std::string ("Failed to receive header: ") +
+        (received < 0 ? gnutls_strerror(received) : "connection lost?");
+  }
 
   // Decode the length.
   unsigned long expected = (header[0]<<24) |
@@ -525,7 +522,11 @@ void TLSClient::recv (std::string& data)
   if (_debug)
     std::cout << "c: INFO expecting " << expected << " bytes.\n";
 
-  // TODO This would be a good place to assert 'expected < _limit'.
+  if (_limit && expected >= (unsigned long) _limit) {
+    std::ostringstream err_str;
+    err_str << "Expected message size " << expected << " is larger than allowed limit " << _limit;
+    throw err_str.str ();
+  }
 
   // Arbitrary buffer size.
   char buffer[MAX_BUF];
@@ -535,13 +536,18 @@ void TLSClient::recv (std::string& data)
   // fits in the buffer.
   do
   {
+    int chunk_size = 0;
     do
     {
-      received = gnutls_record_recv (_session, buffer, MAX_BUF - 1); // All
+      received = gnutls_record_recv (_session, buffer + chunk_size, MAX_BUF - chunk_size); // All
+      if (received > 0) {
+        total += received;
+        chunk_size += received;
+      }
     }
-    while (received > 0 &&
-           (errno == GNUTLS_E_INTERRUPTED ||
-            errno == GNUTLS_E_AGAIN));
+    while ((received > 0 && (unsigned long) total < expected && chunk_size < MAX_BUF) ||
+            received == GNUTLS_E_INTERRUPTED ||
+            received == GNUTLS_E_AGAIN);
 
     // Other end closed the connection.
     if (received == 0)
@@ -552,17 +558,10 @@ void TLSClient::recv (std::string& data)
     }
 
     // Something happened.
-    if (received < 0 && gnutls_error_is_fatal (received) == 0) // All
-    {
-      if (_debug)
-        std::cout << "c: WARNING " << gnutls_strerror (received) << '\n'; // All
-    }
-    else if (received < 0)
+    if (received < 0)
       throw std::string (gnutls_strerror (received)); // All
 
-    buffer [received] = '\0';
-    data += buffer;
-    total += received;
+    data.append (buffer, chunk_size);
 
     // Stop at defined limit.
     if (_limit && total > _limit)

--- a/src/TLSServer.cpp
+++ b/src/TLSServer.cpp
@@ -29,6 +29,7 @@
 #ifdef HAVE_LIBGNUTLS
 
 #include <iostream>
+#include <sstream>
 #include <unistd.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -49,6 +50,7 @@
 #include <format.h>
 
 #define DH_BITS 2048
+#define HEADER_SIZE 4
 #define MAX_BUF 16384
 
 #if GNUTLS_VERSION_NUMBER < 0x030406
@@ -608,24 +610,15 @@ void TLSTransaction::send (const std::string& data)
   packet[3] = l;
 
   unsigned int total = 0;
-  unsigned int remaining = packet.length ();
 
-  while (total < packet.length ())
+  int status;
+  do
   {
-    int status;
-    do
-    {
-      status = gnutls_record_send (_session, packet.c_str () + total, remaining); // All
-    }
-    while (errno == GNUTLS_E_INTERRUPTED ||
-           errno == GNUTLS_E_AGAIN);
-
-    if (status == -1)
-      break;
-
-    total     += (unsigned int) status;
-    remaining -= (unsigned int) status;
+    status = gnutls_record_send (_session, packet.c_str () + total, packet.length () - total); // All
   }
+  while ((status > 0 && (total += status) < packet.length ()) ||
+          status == GNUTLS_E_INTERRUPTED ||
+          status == GNUTLS_E_AGAIN);
 
   if (_debug)
     std::cout << "s: INFO Sending 'XXXX"
@@ -639,18 +632,22 @@ void TLSTransaction::recv (std::string& data)
 {
   data = "";          // No appending of data.
   int received = 0;
+  int total = 0;
 
   // Get the encoded length.
-  unsigned char header[4] {};
+  unsigned char header[HEADER_SIZE] {};
   do
   {
-    received = gnutls_record_recv (_session, header, 4); // All
+    received = gnutls_record_recv (_session, header + total, HEADER_SIZE - total); // All
   }
-  while (received > 0 &&
-         (errno == GNUTLS_E_INTERRUPTED ||
-          errno == GNUTLS_E_AGAIN));
+  while ((received > 0 && (total += received) < HEADER_SIZE) ||
+          received == GNUTLS_E_INTERRUPTED ||
+          received == GNUTLS_E_AGAIN);
 
-  int total = received;
+  if (total < HEADER_SIZE) {
+    throw std::string ("Failed to receive header: ") +
+        (received < 0 ? gnutls_strerror(received) : "connection lost?");
+  }
 
   // Decode the length.
   unsigned long expected = (header[0]<<24) |
@@ -660,7 +657,11 @@ void TLSTransaction::recv (std::string& data)
   if (_debug)
     std::cout << "s: INFO expecting " << expected << " bytes.\n";
 
-  // TODO This would be a good place to assert 'expected < _limit'.
+  if (_limit && expected >= (unsigned long) _limit) {
+    std::ostringstream err_str;
+    err_str << "Expected message size " << expected << " is larger than allowed limit " << _limit;
+    throw err_str.str ();
+  }
 
   // Arbitrary buffer size.
   char buffer[MAX_BUF];
@@ -670,13 +671,18 @@ void TLSTransaction::recv (std::string& data)
   // fits in the buffer.
   do
   {
+    int chunk_size = 0;
     do
     {
-      received = gnutls_record_recv (_session, buffer, MAX_BUF - 1); // All
+      received = gnutls_record_recv (_session, buffer + chunk_size, MAX_BUF - chunk_size); // All
+      if (received > 0) {
+        total += received;
+        chunk_size += received;
+      }
     }
-    while (received > 0 &&
-           (errno == GNUTLS_E_INTERRUPTED ||
-            errno == GNUTLS_E_AGAIN));
+    while ((received > 0 && (unsigned long) total < expected && chunk_size < MAX_BUF) ||
+            received == GNUTLS_E_INTERRUPTED ||
+            received == GNUTLS_E_AGAIN);
 
     // Other end closed the connection.
     if (received == 0)
@@ -687,17 +693,10 @@ void TLSTransaction::recv (std::string& data)
     }
 
     // Something happened.
-    if (received < 0 && gnutls_error_is_fatal (received) == 0) // All
-    {
-      if (_debug)
-        std::cout << "c: WARNING " << gnutls_strerror (received) << '\n'; // All
-    }
-    else if (received < 0)
+    if (received < 0)
       throw std::string (gnutls_strerror (received)); // All
 
-    buffer [received] = '\0';
-    data += buffer;
-    total += received;
+    data.append (buffer, chunk_size);
 
     // Stop at defined limit.
     if (_limit && total > _limit)


### PR DESCRIPTION
- do not check errno on successful function calls (it might not be
  cleared after previous failed one)
- GNUTLS_E_* are not passed through errno but as function return value
- therefore there's more error spectrum than -1
- do not assume whole header is received, check number of bytes fetched

small additional improvements:
- read as many bytes into buffer as possible before appending to data
- skip writing nul byte at the end of buffer and use append() instead
- additional sanity checks